### PR TITLE
対象Noがロック中か返せるようにした

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -114,6 +114,13 @@ class App < Sinatra::Base
     redirect uri "/"
   end
 
+  post '/:name/:no/locking' do
+    _, server = app_and_server params[:name], params[:no]
+
+    "#{server[:l] == true}"
+  end
+
+
   # github webhook
   post '/webhook/unlock/:name' do
     github_event = request.env['HTTP_X_GITHUB_EVENT']

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -85,6 +85,27 @@ describe App do
       assert last_response.body == 'foo3'
     end
 
+    it "locking" do
+      post '/foo', branch: 'teeeest' # create new app
+
+      post "/foo/1/locking"
+      assert last_response.status == 200
+      assert last_response.body == 'false'
+
+      post '/foo/1/lock'
+      post '/foo/1/locking'
+      assert last_response.status == 200
+      assert last_response.body == 'true'
+
+      delete '/foo/1/lock'
+      post '/foo/1/locking'
+      assert last_response.status == 200
+      assert last_response.body == 'false'
+
+      post '/foo/5/locking'
+      assert last_response.status == 404
+    end
+
     it 'allow /' do
       post '/foo', branch: 'bar/baz/wow'
       assert last_response.status == 200


### PR DESCRIPTION
ロック中のときは、DBリストアしないようにしたいため、ロック中か返せるようにした
ステージングサーバでFeatureFlagを有効にしても、新しくデプロイされるたびにDBがリストアされてしまうため、たまに困る
（いつかのプロダクト定例で相談したのですが、資料見つからず...）

このPRがマージされた後に、Pharmsのcircle ciのコンフィグを触る予定

他のプロダクトの方々も利用中だと思うが、新しくパスを切ったので影響はない

マージで自動デプロイされる...？